### PR TITLE
Update repo clone url

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Below are a set of instructions that may help you get a local development enviro
 
 ```sh
 # Get the gem/npm package source locally
-git clone cubism
+git clone https://github.com/julianrubisch/cubism.git
 yarn install # install all of the npm package's dependencies
 yarn link # set the local machine's cubism npm package's lookup to this local path
 


### PR DESCRIPTION
Looks like the `git clone cubism` shorthand syntax just works with [`hub`](https://hub.github.com)