### PR TITLE
Multi worker setup

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,10 @@ jobs:
           key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-gems-
+      - name: Set up Redis 4
+        uses: supercharge/redis-github-action@1.2.0
+        with:
+          redis-version: 4
       - name: Install sqlite headers
         run: |
           sudo apt-get update

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Lightweight Resource-Based Presence Solution with CableReady.
 - [Usage](#usage)
 - [Installation](#installation)
 - [API](#api)
+- [Limitations](#limitations)
 - [Gotchas](#gotchas)
 - [Contributing](#contributing)
 - [License](#license)
@@ -55,6 +56,8 @@ Using the `cubicle_for` helper, you can set up a presence indicator. It will
   <%= users.map(&:username).join(", ")
 <% end %>
 ```
+
+**Important!** due to technical limitations the cubism block does _not_ act as a closure, i.e. it has _only_ access to the `users` variable passed to it - think of it more as a self-contained component.
 
 ## Installation
 Add this line to your application's Gemfile:
@@ -98,6 +101,11 @@ The `cubicle_for` helper accepts the following options as keyword arguments:
 - `disappear_trigger`: a JavaScript event name (e.g. `:blur`) to use. (Can also be a singular string, which will be converted to an array). The default is `:disconnect`, i.e. remove a user form the present users list when the element disconnects from the DOM.
 - `trigger_root`: a CSS selector to attach the appear/disappear events to. Defaults to the `cubicle-element` itself.
 - `html_options` are passed to the TagBuilder.
+
+## Limitations
+
+### Supported Template Handlers
+- ERB
 
 ## Gotchas
 

--- a/app/helpers/cubism_helper.rb
+++ b/app/helpers/cubism_helper.rb
@@ -2,17 +2,19 @@ module CubismHelper
   include CableReady::StreamIdentifier
 
   def cubicle_for(resource, user, html_options: {}, appear_trigger: :connect, disappear_trigger: nil, trigger_root: nil, exclude_current_user: true, &block)
-    key = "#{block.source_location.join(":")}:#{resource.to_gid}:#{user.to_gid}"
-    digested_id = ActiveSupport::Digest.hexdigest(key)
+    block_key = block.source_location.join(":")
+    resource_user_key = "#{resource.to_gid}:#{user.to_gid}"
+    digested_block_key = ActiveSupport::Digest.hexdigest(block_key)
+    digested_user_resource_key = ActiveSupport::Digest.hexdigest(resource_user_key)
 
-    Cubism.store[digested_id] = Cubism::BlockStoreItem.new(context: self, block: block.dup)
+    Cubism.store[digested_block_key] = Cubism::BlockStoreItem.new(context: self, block: block.dup)
     tag.cubicle_element(
       identifier: signed_stream_identifier(resource.to_gid.to_s),
       user: user.to_sgid.to_s,
       "appear-trigger": Array(appear_trigger).join(","),
       "disappear-trigger": disappear_trigger,
       "trigger-root": trigger_root,
-      id: "cubicle-#{digested_id}",
+      id: "cubicle-#{digested_block_key}-#{digested_user_resource_key}",
       "exclude-current-user": exclude_current_user,
       **html_options
     )

--- a/app/helpers/cubism_helper.rb
+++ b/app/helpers/cubism_helper.rb
@@ -2,12 +2,17 @@ module CubismHelper
   include CableReady::StreamIdentifier
 
   def cubicle_for(resource, user, html_options: {}, appear_trigger: :connect, disappear_trigger: nil, trigger_root: nil, exclude_current_user: true, &block)
-    block_key = block.source_location.join(":")
+    block_location = block.source_location.join(":")
     resource_user_key = "#{resource.to_gid}:#{user.to_gid}"
-    digested_block_key = ActiveSupport::Digest.hexdigest(block_key)
+    digested_block_key = ActiveSupport::Digest.hexdigest(block_location)
     digested_user_resource_key = ActiveSupport::Digest.hexdigest(resource_user_key)
 
-    Cubism.store[digested_block_key] = Cubism::BlockStoreItem.new(context: self, block: block.dup)
+    Cubism.store[digested_block_key] = Cubism::BlockStoreItem.new(
+      block_location: block_location,
+      resource_gid: resource.to_gid.to_s,
+      user_gid: user.to_gid.to_s
+    )
+
     tag.cubicle_element(
       identifier: signed_stream_identifier(resource.to_gid.to_s),
       user: user.to_sgid.to_s,

--- a/app/helpers/cubism_helper.rb
+++ b/app/helpers/cubism_helper.rb
@@ -7,13 +7,14 @@ module CubismHelper
     resource_user_key = "#{resource.to_gid}:#{user.to_gid}"
     digested_block_key = ActiveSupport::Digest.hexdigest("#{block_location}:#{resource_user_key}")
 
-    store_item = Cubism::BlockStoreItem.new(
+    # the store item (identified by block location, resource, and user) might already be present
+    store_item = Cubism.store[digested_block_key] || Cubism::BlockStoreItem.new(
       block_location: block_location,
       resource_gid: resource.to_gid.to_s,
       user_gid: user.to_gid.to_s
     )
 
-    if Cubism.store[digested_block_key].blank? && !block_location.start_with?("inline template")
+    if Cubism.store[digested_block_key]&.block_source.blank? && !block_location.start_with?("inline template")
       lines = File.readlines(filename)[lineno - 1..]
 
       preprocessor = Cubism::Preprocessor.new(source: lines.join.squish, view_context: self)

--- a/app/helpers/cubism_helper.rb
+++ b/app/helpers/cubism_helper.rb
@@ -2,10 +2,10 @@ module CubismHelper
   include CableReady::StreamIdentifier
 
   def cubicle_for(resource, user, html_options: {}, appear_trigger: :connect, disappear_trigger: nil, trigger_root: nil, exclude_current_user: true, &block)
+    filename, lineno = block.source_location
     block_location = block.source_location.join(":")
     resource_user_key = "#{resource.to_gid}:#{user.to_gid}"
-    digested_block_key = ActiveSupport::Digest.hexdigest(block_location)
-    digested_user_resource_key = ActiveSupport::Digest.hexdigest(resource_user_key)
+    digested_block_key = ActiveSupport::Digest.hexdigest("#{block_location}:#{resource_user_key}")
 
     Cubism.store[digested_block_key] = Cubism::BlockStoreItem.new(
       block_location: block_location,
@@ -13,13 +13,20 @@ module CubismHelper
       user_gid: user.to_gid.to_s
     )
 
+    if Cubism.store[block_location].blank? && !block_location.start_with?("inline template")
+      lines = File.readlines(filename)[lineno - 1..]
+
+      preprocessor = Cubism::Preprocessor.new(source: lines.join.squish, view_context: self)
+      Cubism.store[block_location] = preprocessor.process
+    end
+
     tag.cubicle_element(
       identifier: signed_stream_identifier(resource.to_gid.to_s),
       user: user.to_sgid.to_s,
       "appear-trigger": Array(appear_trigger).join(","),
       "disappear-trigger": disappear_trigger,
       "trigger-root": trigger_root,
-      id: "cubicle-#{digested_block_key}-#{digested_user_resource_key}",
+      id: "cubicle-#{digested_block_key}",
       "exclude-current-user": exclude_current_user,
       **html_options
     )

--- a/lib/cubism.rb
+++ b/lib/cubism.rb
@@ -14,5 +14,5 @@ module Cubism
 
   mattr_accessor :user_class, instance_writer: false, instance_reader: false
 
-  mattr_reader :store, instance_reader: false, default: Cubism::CubicleBlockStore.instance
+  mattr_accessor :store, instance_reader: false
 end

--- a/lib/cubism.rb
+++ b/lib/cubism.rb
@@ -4,11 +4,13 @@ require "cubism/version"
 require "cubism/engine"
 require "cubism/broadcaster"
 require "cubism/cubicle_block_store"
+require "cubism/preprocessor"
 
 module Cubism
   extend ActiveSupport::Autoload
 
   autoload :Broadcaster, "cubism/broadcaster"
+  autoload :Preprocessor, "cubism/preprocessor"
 
   mattr_accessor :user_class, instance_writer: false, instance_reader: false
 

--- a/lib/cubism/broadcaster.rb
+++ b/lib/cubism/broadcaster.rb
@@ -13,12 +13,14 @@ module Cubism
 
     def broadcast
       resource.cubicle_element_ids.to_a.each do |element_id|
-        /cubicle-(?<block_key>.+)-(?<user_resource_key>.+)/ =~ element_id
-        next if Cubism.store[block_key].blank?
+        /cubicle-(?<block_key>.+)/ =~ element_id
+        block_store_item = Cubism.store[block_key]
 
-        block = Cubism.store[block_key].block
-        view_context = Cubism.store[block_key].context
-        html = view_context.capture(resource.present_users_for_element_id(element_id), &block)
+        next if block_store_item.blank?
+
+        block_source = Cubism.store[block_store_item.block_location]
+
+        html = ApplicationController.render(inline: block_source, locals: {users: resource.present_users_for_element_id(element_id)})
 
         cable_ready[element_id].inner_html(
           selector: "cubicle-element##{element_id}[identifier='#{signed_stream_identifier(resource.to_global_id.to_s)}']",

--- a/lib/cubism/broadcaster.rb
+++ b/lib/cubism/broadcaster.rb
@@ -14,13 +14,11 @@ module Cubism
     def broadcast
       resource.cubicle_element_ids.to_a.each do |element_id|
         /cubicle-(?<block_key>.+)/ =~ element_id
-        block_store_item = Cubism.store[block_key]
+        store_item = Cubism.store[block_key]
 
-        next if block_store_item.blank?
+        next if store_item.blank?
 
-        block_source = Cubism.store[block_store_item.block_location]
-
-        html = ApplicationController.render(inline: block_source, locals: {users: resource.present_users_for_element_id(element_id)})
+        html = ApplicationController.render(inline: store_item.block_source, locals: {users: resource.present_users_for_element_id(element_id)})
 
         cable_ready[element_id].inner_html(
           selector: "cubicle-element##{element_id}[identifier='#{signed_stream_identifier(resource.to_global_id.to_s)}']",

--- a/lib/cubism/broadcaster.rb
+++ b/lib/cubism/broadcaster.rb
@@ -13,7 +13,7 @@ module Cubism
 
     def broadcast
       resource.cubicle_element_ids.to_a.each do |element_id|
-        /cubicle-(?<block_key>.+)/ =~ element_id
+        /cubicle-(?<block_key>.+)-(?<user_resource_key>.+)/ =~ element_id
         next if Cubism.store[block_key].blank?
 
         block = Cubism.store[block_key].block

--- a/lib/cubism/cubicle_block_store.rb
+++ b/lib/cubism/cubicle_block_store.rb
@@ -31,5 +31,13 @@ module Cubism
     end
   end
 
-  BlockStoreItem = Struct.new(:context, :block, keyword_init: true)
+  BlockStoreItem = Struct.new(:block_location, :user_gid, :resource_gid, keyword_init: true) do
+    def user
+      GlobalID::Locator.locate self[:user_gid]
+    end
+
+    def resource
+      GlobalID::Locator.locate self[:resource_gid]
+    end
+  end
 end

--- a/lib/cubism/cubicle_block_store.rb
+++ b/lib/cubism/cubicle_block_store.rb
@@ -1,27 +1,30 @@
 module Cubism
   class CubicleBlockStore
-    include Singleton
-
     delegate_missing_to :@blocks
 
     def initialize
-      @blocks = {}
+      @blocks = Kredis.hash "cubism-blocks"
     end
 
     def [](key)
-      @blocks[key]
+      Marshal.load(@blocks[key]) if @blocks[key]
     end
 
     def []=(key, value)
       mutex.synchronize do
-        @blocks[key] = value
+        @blocks[key] = Marshal.dump value
       end
     end
 
     def clear
       mutex.synchronize do
-        @blocks.clear
+        # kredis #remove
+        @blocks.remove
       end
+    end
+
+    def size
+      @blocks.to_h.size
     end
 
     private
@@ -31,13 +34,23 @@ module Cubism
     end
   end
 
-  BlockStoreItem = Struct.new(:block_location, :user_gid, :resource_gid, keyword_init: true) do
+  BlockStoreItem = Struct.new(:block_location, :block_source, :user_gid, :resource_gid, keyword_init: true) do
     def user
       GlobalID::Locator.locate self[:user_gid]
     end
 
     def resource
       GlobalID::Locator.locate self[:resource_gid]
+    end
+
+    def marshal_dump
+      to_h
+    end
+
+    def marshal_load(serialized_item)
+      %i[block_location block_source user_gid resource_gid].each do |arg|
+        send("#{arg}=", serialized_item[arg])
+      end
     end
   end
 end

--- a/lib/cubism/engine.rb
+++ b/lib/cubism/engine.rb
@@ -1,4 +1,7 @@
 module Cubism
   class Engine < ::Rails::Engine
+    initializer "cubism.store" do
+      Cubism.store = Cubism::CubicleBlockStore.new
+    end
   end
 end

--- a/lib/cubism/preprocessor.rb
+++ b/lib/cubism/preprocessor.rb
@@ -17,6 +17,8 @@ module Cubism
       @source
     end
 
+    private
+
     def do_parse
       ActionView::Template::Handlers::ERB::Erubi.new(@source).evaluate(@view_context)
     rescue SyntaxError

--- a/lib/cubism/preprocessor.rb
+++ b/lib/cubism/preprocessor.rb
@@ -22,7 +22,7 @@ module Cubism
     def do_parse
       ActionView::Template::Handlers::ERB::Erubi.new(@source).evaluate(@view_context)
     rescue SyntaxError
-      end_at_end = /(<%\s+end\s+%\>)\z/.match(@source)
+      end_at_end = /(<%\s+end\s+%>)\z/.match(@source)
       @source = end_at_end ? @source[..-(end_at_end[0].length + 1)] : @source[..-2]
       do_parse
     end

--- a/lib/cubism/preprocessor.rb
+++ b/lib/cubism/preprocessor.rb
@@ -1,7 +1,8 @@
 module Cubism
   class Preprocessor
     def initialize(source:, view_context:)
-      start_pos = /<%= cubicle_for/ =~ source
+      match_data = /<%=\s+cubicle_for.+\|.+\|\s+%>/.match(source)
+      start_pos = match_data.end(0)
       @source = source[start_pos..]
       @view_context = view_context
     end
@@ -19,7 +20,8 @@ module Cubism
     def do_parse
       ActionView::Template::Handlers::ERB::Erubi.new(@source).evaluate(@view_context)
     rescue SyntaxError
-      @source = @source[..-2]
+      end_at_end = /(<%\s+end\s+%\>)\z/.match(@source)
+      @source = end_at_end ? @source[..-(end_at_end[0].length + 1)] : @source[..-2]
       do_parse
     end
   end

--- a/lib/cubism/preprocessor.rb
+++ b/lib/cubism/preprocessor.rb
@@ -2,7 +2,7 @@ module Cubism
   class Preprocessor
     def initialize(source:, view_context:)
       match_data = /<%=\s+cubicle_for.+\|.+\|\s+%>/.match(source)
-      start_pos = match_data.end(0)
+      start_pos = match_data&.end(0) || 0
       @source = source[start_pos..]
       @view_context = view_context
     end

--- a/lib/cubism/preprocessor.rb
+++ b/lib/cubism/preprocessor.rb
@@ -1,0 +1,26 @@
+module Cubism
+  class Preprocessor
+    def initialize(source:, view_context:)
+      start_pos = /<%= cubicle_for/ =~ source
+      @source = source[start_pos..]
+      @view_context = view_context
+    end
+
+    def process
+      begin
+        do_parse
+      rescue NameError
+        # we ignore any name errors from unset instance variables or local assigns here
+      end
+
+      @source
+    end
+
+    def do_parse
+      ActionView::Template::Handlers::ERB::Erubi.new(@source).evaluate(@view_context)
+    rescue SyntaxError
+      @source = @source[..-2]
+      do_parse
+    end
+  end
+end

--- a/test/broadcaster_test.rb
+++ b/test/broadcaster_test.rb
@@ -12,7 +12,7 @@ class BroadcasterTest < ActionView::TestCase
 
     Cubism.stubs(:store).returns({
       "foo" => Cubism::BlockStoreItem.new(block_location: "test:1", block_source: "<div><%= users.map(&:username).to_sentence %></div>", user_gid: users(:one).to_gid.to_s, resource_gid: posts(:one).to_gid.to_s),
-      "bar" => Cubism::BlockStoreItem.new(block_location: "test:1", block_source: "<div><%= users.map(&:username).to_sentence %></div>", user_gid: users(:two).to_gid.to_s, resource_gid: posts(:one).to_gid.to_s),
+      "bar" => Cubism::BlockStoreItem.new(block_location: "test:1", block_source: "<div><%= users.map(&:username).to_sentence %></div>", user_gid: users(:two).to_gid.to_s, resource_gid: posts(:one).to_gid.to_s)
     })
   end
 
@@ -40,9 +40,9 @@ def with_mocked_cable_ready(elements_with_users, resource)
     cable_ready_channel
       .expects(:inner_html)
       .with({
-              selector: "cubicle-element##{element_id}[identifier='#{signed_stream_identifier(resource.to_global_id.to_s)}']",
-              html: "<div>#{user.username}</div>"
-            })
+        selector: "cubicle-element##{element_id}[identifier='#{signed_stream_identifier(resource.to_global_id.to_s)}']",
+        html: "<div>#{user.username}</div>"
+      })
       .returns(operation_mock)
     cable_ready_mock.expects(:[]).with(element_id).returns(cable_ready_channel)
   end

--- a/test/broadcaster_test.rb
+++ b/test/broadcaster_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class BroadcasterTest < ActionView::TestCase
+  include CableReady::StreamIdentifier
+
   setup do
     @post = posts(:one)
     @post.stubs(:cubicle_element_ids).returns(%w[cubicle-foo cubicle-bar])
@@ -8,39 +10,40 @@ class BroadcasterTest < ActionView::TestCase
     @post.stubs(:present_users_for_element_id).with("cubicle-bar").returns([users(:two)])
     @broadcaster = Cubism::Broadcaster.new(resource: @post)
 
-    @foo_user_list = []
-    @bar_user_list = []
-
     Cubism.stubs(:store).returns({
-      "foo" => Cubism::BlockStoreItem.new(context: view, block: ->(users) { @foo_user_list = users }),
-      "bar" => Cubism::BlockStoreItem.new(context: view, block: ->(users) { @bar_user_list = users })
+      "foo" => Cubism::BlockStoreItem.new(block_location: "test:1", block_source: "<div><%= users.map(&:username).to_sentence %></div>", user_gid: users(:one).to_gid.to_s, resource_gid: posts(:one).to_gid.to_s),
+      "bar" => Cubism::BlockStoreItem.new(block_location: "test:1", block_source: "<div><%= users.map(&:username).to_sentence %></div>", user_gid: users(:two).to_gid.to_s, resource_gid: posts(:one).to_gid.to_s),
     })
   end
 
   test "it broadcasts to all registered element ids" do
-    with_mocked_cable_ready(%w[cubicle-foo cubicle-bar]) do |cable_ready_mock|
+    with_mocked_cable_ready({"cubicle-foo" => users(:one), "cubicle-bar" => users(:two)}, @post) do |cable_ready_mock|
       members = Set[]
-      members.stubs(:members).returns([users(:one).id])
+      members.stubs(:members).returns([users(:one).id, users(:two).id])
       @post.stubs(:present_users).returns(members)
 
       @broadcaster.expects(:cable_ready).returns(cable_ready_mock).twice
 
       @broadcaster.broadcast
-
-      assert_equal [users(:one)], @foo_user_list
-      assert_equal [users(:two)], @bar_user_list
     end
   end
 end
 
-def with_mocked_cable_ready(element_ids)
+def with_mocked_cable_ready(elements_with_users, resource)
   operation_mock = mock
-  operation_mock.expects(:broadcast).times(element_ids.size)
-  cable_ready_channel = mock
-  cable_ready_channel.expects(:inner_html).returns(operation_mock).times(element_ids.size)
+  operation_mock.expects(:broadcast).times(elements_with_users.size)
+
   cable_ready_mock = mock
 
-  element_ids.each do |element_id|
+  elements_with_users.each do |element_id, user|
+    cable_ready_channel = mock
+    cable_ready_channel
+      .expects(:inner_html)
+      .with({
+              selector: "cubicle-element##{element_id}[identifier='#{signed_stream_identifier(resource.to_global_id.to_s)}']",
+              html: "<div>#{user.username}</div>"
+            })
+      .returns(operation_mock)
     cable_ready_mock.expects(:[]).with(element_id).returns(cable_ready_channel)
   end
 

--- a/test/dummy/config/redis/shared.yml
+++ b/test/dummy/config/redis/shared.yml
@@ -1,0 +1,16 @@
+default: &default
+  host: <%= ENV.fetch("REDIS_EVICTED_URL", "127.0.0.1") %>
+  port: 6379
+  timeout: 1
+
+development:
+  <<: *default
+
+staging:
+  <<: *default
+
+production:
+  <<: *default
+
+test:
+  <<: *default

--- a/test/dummy/test/fixtures/users.yml
+++ b/test/dummy/test/fixtures/users.yml
@@ -1,7 +1,7 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  username: MyString
+  username: user_one
 
 two:
-  username: MyString
+  username: user_two

--- a/test/rendering/preprocessor_test.rb
+++ b/test/rendering/preprocessor_test.rb
@@ -1,0 +1,61 @@
+class PreprocessorTest < ActionView::TestCase
+  test "it extracts a simple cubicle_for block" do
+    source = <<-ERB
+      <%= cubicle_for post, user do |users| %>
+        <span class="presence">
+          <%= users.map(&:username).to_sentence %>
+        <span>
+      <% end %>
+    ERB
+
+    result = <<~ERB
+      <span class="presence">
+        <%= users.map(&:username).to_sentence %>
+      <span>
+    ERB
+
+    preprocessor = Cubism::Preprocessor.new(source: source, view_context: self)
+
+    assert_equal result.squish, preprocessor.process.squish
+  end
+
+  test "it respects ERB tags nested in the block" do
+    source = <<-ERB
+      <%= cubicle_for post, user do |users| %>
+        <% if users.size > 0 %>
+          <span class="presence">
+            <%= users.map(&:username).to_sentence %>
+          <span>
+        <% end %>
+      <% end %>
+    ERB
+
+    result = <<~ERB
+      <% if users.size > 0 %>
+        <span class="presence">
+          <%= users.map(&:username).to_sentence %>
+        <span>
+      <% end %>
+    ERB
+
+    preprocessor = Cubism::Preprocessor.new(source: source, view_context: self)
+
+    assert_equal result.squish, preprocessor.process.squish
+  end
+
+  test "it respects render calls nested in the block" do
+    source = <<-ERB
+      <%= cubicle_for post, user do |users| %>
+        <%= render "presence_partial", users: users %>
+      <% end %>
+    ERB
+
+    result = <<~ERB
+      <%= render "presence_partial", users: users %>
+    ERB
+
+    preprocessor = Cubism::Preprocessor.new(source: source, view_context: self)
+
+    assert_equal result.squish, preprocessor.process.squish
+  end
+end


### PR DESCRIPTION
# Bug Fix

## Description

Previously, blocks were fetched from a singleton which (obviously) cannot work across multiple processes.

This PR introduces a way to extract the actual ERB source of the cubism block via a `Preprocessor` and actually render it inline in `Broadcaster`. Since kredis is in the picture already, it is used to store the block location, source, as well as resource and user IDs under a combined hashed key.