### PR TITLE
Async dom mutations

### DIFF
--- a/javascript/elements/cubicle.js
+++ b/javascript/elements/cubicle.js
@@ -1,10 +1,10 @@
-import CableReady, { SubscribingElement } from "cable_ready";
-import { debounce } from "cable_ready/javascript/utils";
+import CableReady, { SubscribingElement } from 'cable_ready'
+import { debounce } from 'cable_ready/javascript/utils'
 
 export class Cubicle extends SubscribingElement {
-  constructor() {
-    super();
-    const shadowRoot = this.attachShadow({ mode: "open" });
+  constructor () {
+    super()
+    const shadowRoot = this.attachShadow({ mode: 'open' })
     shadowRoot.innerHTML = `
 <style>
   :host {
@@ -12,132 +12,129 @@ export class Cubicle extends SubscribingElement {
   }
 </style>
 <slot></slot>
-`;
+`
 
-    this.triggerRoot = this;
+    this.triggerRoot = this
   }
 
-  async connectedCallback() {
-    if (this.preview) return;
+  async connectedCallback () {
+    if (this.preview) return
 
-    this.appear = debounce(this.appear.bind(this), 20);
+    this.appear = debounce(this.appear.bind(this), 20)
 
-    this.appearTriggers = this.getAttribute("appear-trigger")
-      ? this.getAttribute("appear-trigger").split(",")
-      : [];
-    this.disappearTriggers = this.getAttribute("disappear-trigger")
-      ? this.getAttribute("disappear-trigger").split(",")
-      : [];
-    this.triggerRootSelector = this.getAttribute("trigger-root");
+    this.appearTriggers = this.getAttribute('appear-trigger')
+      ? this.getAttribute('appear-trigger').split(',')
+      : []
+    this.disappearTriggers = this.getAttribute('disappear-trigger')
+      ? this.getAttribute('disappear-trigger').split(',')
+      : []
+    this.triggerRootSelector = this.getAttribute('trigger-root')
 
-    this.consumer = await CableReady.consumer;
+    this.consumer = await CableReady.consumer
 
-    this.channel = this.createSubscription();
+    this.channel = this.createSubscription()
 
     this.mutationObserver = new MutationObserver((mutationsList, observer) => {
       if (this.triggerRootSelector) {
         for (const mutation of mutationsList) {
-          const root = document.querySelector(this.triggerRootSelector);
+          const root = document.querySelector(this.triggerRootSelector)
           if (root) {
-            this.uninstall();
-            this.triggerRoot = root;
-            this.install();
+            this.uninstall()
+            this.triggerRoot = root
+            this.install()
           }
         }
       }
-      this.mutationObserver.disconnect();
-    });
+      this.mutationObserver.disconnect()
+    })
 
     this.mutationObserver.observe(document, {
       subtree: true,
-      childList: true,
-    });
+      childList: true
+    })
   }
 
-  disconnectedCallback() {
-    this.disappear();
-    super.disconnectedCallback();
+  disconnectedCallback () {
+    this.disappear()
+    super.disconnectedCallback()
   }
 
-  install() {
-    if (this.appearTriggers.includes("connect")) {
-      this.appear();
+  install () {
+    if (this.appearTriggers.includes('connect')) {
+      this.appear()
     }
 
     this.appearTriggers
-      .filter((eventName) => eventName !== "connect")
-      .forEach((eventName) => {
-        this.triggerRoot.addEventListener(eventName, this.appear.bind(this));
-      });
+      .filter(eventName => eventName !== 'connect')
+      .forEach(eventName => {
+        this.triggerRoot.addEventListener(eventName, this.appear.bind(this))
+      })
 
-    this.disappearTriggers.forEach((eventName) => {
-      this.triggerRoot.addEventListener(eventName, this.disappear.bind(this));
-    });
+    this.disappearTriggers.forEach(eventName => {
+      this.triggerRoot.addEventListener(eventName, this.disappear.bind(this))
+    })
   }
 
-  uninstall() {
+  uninstall () {
     this.appearTriggers
-      .filter((eventName) => eventName !== "connect")
-      .forEach((eventName) => {
-        this.triggerRoot.removeEventListener(eventName, this.appear.bind(this));
-      });
+      .filter(eventName => eventName !== 'connect')
+      .forEach(eventName => {
+        this.triggerRoot.removeEventListener(eventName, this.appear.bind(this))
+      })
 
-    this.disappearTriggers.forEach((eventName) => {
-      this.triggerRoot.removeEventListener(
-        eventName,
-        this.disappear.bind(this)
-      );
-    });
+    this.disappearTriggers.forEach(eventName => {
+      this.triggerRoot.removeEventListener(eventName, this.disappear.bind(this))
+    })
   }
 
-  appear() {
-    if (this.channel) this.channel.perform("appear");
+  appear () {
+    if (this.channel) this.channel.perform('appear')
   }
 
-  disappear() {
-    if (this.channel) this.channel.perform("disappear");
+  disappear () {
+    if (this.channel) this.channel.perform('disappear')
   }
 
-  performOperations(data) {
+  performOperations (data) {
     if (data.cableReady) {
-      CableReady.perform(data.operations);
+      CableReady.perform(data.operations)
     }
   }
 
-  createSubscription() {
+  createSubscription () {
     if (!this.consumer) {
       console.error(
-        "The `cubicle-element` helper cannot connect without an ActionCable consumer."
-      );
-      return;
+        'The `cubicle-element` helper cannot connect without an ActionCable consumer.'
+      )
+      return
     }
 
     return this.consumer.subscriptions.create(
       {
         channel: this.channelName,
-        identifier: this.getAttribute("identifier"),
-        user: this.getAttribute("user"),
+        identifier: this.getAttribute('identifier'),
+        user: this.getAttribute('user'),
         element_id: this.id,
         exclude_current_user:
-          this.getAttribute("exclude-current-user") === "true",
+          this.getAttribute('exclude-current-user') === 'true'
       },
       {
         connected: () => {
-          this.install();
+          this.install()
         },
         disconnected: () => {
-          this.disappear();
-          this.uninstall();
+          this.disappear()
+          this.uninstall()
         },
         rejected: () => {
-          this.uninstall();
+          this.uninstall()
         },
-        received: this.performOperations.bind(this),
+        received: this.performOperations.bind(this)
       }
-    );
+    )
   }
 
-  get channelName() {
-    return "Cubism::PresenceChannel";
+  get channelName () {
+    return 'Cubism::PresenceChannel'
   }
 }

--- a/javascript/elements/cubicle.js
+++ b/javascript/elements/cubicle.js
@@ -1,9 +1,9 @@
-import CableReady, { SubscribingElement } from 'cable_ready'
+import CableReady, { SubscribingElement } from "cable_ready";
 
 export class Cubicle extends SubscribingElement {
-  constructor () {
-    super()
-    const shadowRoot = this.attachShadow({ mode: 'open' })
+  constructor() {
+    super();
+    const shadowRoot = this.attachShadow({ mode: "open" });
     shadowRoot.innerHTML = `
 <style>
   :host {
@@ -11,112 +11,130 @@ export class Cubicle extends SubscribingElement {
   }
 </style>
 <slot></slot>
-`
+`;
 
-    this.triggerRoot = this
+    this.triggerRoot = this;
   }
 
-  async connectedCallback () {
-    if (this.preview) return
+  async connectedCallback() {
+    if (this.preview) return;
 
-    this.appearTriggers = this.getAttribute('appear-trigger')
-      ? this.getAttribute('appear-trigger').split(',')
-      : []
-    this.disappearTriggers = this.getAttribute('disappear-trigger')
-      ? this.getAttribute('disappear-trigger').split(',')
-      : []
-    this.triggerRootSelector = this.getAttribute('trigger-root')
+    this.appearTriggers = this.getAttribute("appear-trigger")
+      ? this.getAttribute("appear-trigger").split(",")
+      : [];
+    this.disappearTriggers = this.getAttribute("disappear-trigger")
+      ? this.getAttribute("disappear-trigger").split(",")
+      : [];
+    this.triggerRootSelector = this.getAttribute("trigger-root");
 
-    this.consumer = await CableReady.consumer
+    this.consumer = await CableReady.consumer;
 
-    this.channel = this.createSubscription()
+    this.channel = this.createSubscription();
 
-    if (this.triggerRootSelector) {
-      this.triggerRoot = document.querySelector(this.triggerRootSelector)
-    }
+    this.mutationObserver = new MutationObserver((mutationsList, observer) => {
+      if (this.triggerRootSelector) {
+        for (const mutation of mutationsList) {
+          const root = document.querySelector(this.triggerRootSelector);
+          if (root) {
+            this.uninstall();
+            this.triggerRoot = root;
+            this.install();
+          }
+        }
+      }
+      this.mutationObserver.disconnect();
+    });
+
+    this.mutationObserver.observe(document, {
+      subtree: true,
+      childList: true,
+    });
   }
 
-  disconnectedCallback () {
-    this.disappear()
-    super.disconnectedCallback()
+  disconnectedCallback() {
+    this.disappear();
+    super.disconnectedCallback();
   }
 
-  install () {
-    if (this.appearTriggers.includes('connect')) {
-      this.appear()
+  install() {
+    if (this.appearTriggers.includes("connect")) {
+      this.appear();
     }
 
     this.appearTriggers
-      .filter(eventName => eventName !== 'connect')
-      .forEach(eventName => {
-        this.triggerRoot.addEventListener(eventName, this.appear.bind(this))
-      })
+      .filter((eventName) => eventName !== "connect")
+      .forEach((eventName) => {
+        this.triggerRoot.addEventListener(eventName, this.appear.bind(this));
+      });
 
-    this.disappearTriggers.forEach(eventName => {
-      this.triggerRoot.addEventListener(eventName, this.disappear.bind(this))
-    })
+    this.disappearTriggers.forEach((eventName) => {
+      this.triggerRoot.addEventListener(eventName, this.disappear.bind(this));
+    });
   }
 
-  uninstall () {
+  uninstall() {
     this.appearTriggers
-      .filter(eventName => eventName !== 'connect')
-      .forEach(eventName => {
-        this.triggerRoot.removeEventListener(eventName, this.appear.bind(this))
-      })
+      .filter((eventName) => eventName !== "connect")
+      .forEach((eventName) => {
+        this.triggerRoot.removeEventListener(eventName, this.appear.bind(this));
+      });
 
-    this.disappearTriggers.forEach(eventName => {
-      this.triggerRoot.removeEventListener(eventName, this.disappear.bind(this))
-    })
+    this.disappearTriggers.forEach((eventName) => {
+      this.triggerRoot.removeEventListener(
+        eventName,
+        this.disappear.bind(this)
+      );
+    });
   }
 
-  appear () {
-    if (this.channel) this.channel.perform('appear')
+  appear() {
+    if (this.channel) this.channel.perform("appear");
   }
 
-  disappear () {
-    if (this.channel) this.channel.perform('disappear')
+  disappear() {
+    if (this.channel) this.channel.perform("disappear");
   }
 
-  performOperations (data) {
+  performOperations(data) {
     if (data.cableReady) {
-      CableReady.perform(data.operations)
+      CableReady.perform(data.operations);
     }
   }
 
-  createSubscription () {
+  createSubscription() {
     if (!this.consumer) {
       console.error(
-        'The `cubicle-element` helper cannot connect without an ActionCable consumer.'
-      )
-      return
+        "The `cubicle-element` helper cannot connect without an ActionCable consumer."
+      );
+      return;
     }
 
     return this.consumer.subscriptions.create(
       {
         channel: this.channelName,
-        identifier: this.getAttribute('identifier'),
-        user: this.getAttribute('user'),
+        identifier: this.getAttribute("identifier"),
+        user: this.getAttribute("user"),
         element_id: this.id,
         exclude_current_user:
-          this.getAttribute('exclude-current-user') === 'true'
+          this.getAttribute("exclude-current-user") === "true",
       },
       {
         connected: () => {
-          this.install()
+          this.install();
         },
         disconnected: () => {
-          this.disappear()
-          this.uninstall()
+          this.disappear();
+          this.uninstall();
         },
         rejected: () => {
-          this.uninstall()
+          this.uninstall();
         },
-        received: this.performOperations.bind(this)
+        received: this.performOperations.bind(this),
       }
-    )
+    );
   }
 
-  get channelName () {
-    return 'Cubism::PresenceChannel'
+  get channelName() {
+    return "Cubism::PresenceChannel";
   }
 }

--- a/javascript/elements/cubicle.js
+++ b/javascript/elements/cubicle.js
@@ -1,10 +1,11 @@
-import CableReady, { SubscribingElement } from 'cable_ready'
-import { debounce } from 'cable_ready/javascript/utils'
+/* eslint-disable no-undef */
+import CableReady, { SubscribingElement } from "cable_ready";
+import { debounce } from "cable_ready/javascript/utils";
 
 export class Cubicle extends SubscribingElement {
-  constructor () {
-    super()
-    const shadowRoot = this.attachShadow({ mode: 'open' })
+  constructor() {
+    super();
+    const shadowRoot = this.attachShadow({ mode: "open" });
     shadowRoot.innerHTML = `
 <style>
   :host {
@@ -12,129 +13,133 @@ export class Cubicle extends SubscribingElement {
   }
 </style>
 <slot></slot>
-`
+`;
 
-    this.triggerRoot = this
+    this.triggerRoot = this;
   }
 
-  async connectedCallback () {
-    if (this.preview) return
+  async connectedCallback() {
+    if (this.preview) return;
 
-    this.appear = debounce(this.appear.bind(this), 20)
+    this.appear = debounce(this.appear.bind(this), 20);
 
-    this.appearTriggers = this.getAttribute('appear-trigger')
-      ? this.getAttribute('appear-trigger').split(',')
-      : []
-    this.disappearTriggers = this.getAttribute('disappear-trigger')
-      ? this.getAttribute('disappear-trigger').split(',')
-      : []
-    this.triggerRootSelector = this.getAttribute('trigger-root')
+    this.appearTriggers = this.getAttribute("appear-trigger")
+      ? this.getAttribute("appear-trigger").split(",")
+      : [];
+    this.disappearTriggers = this.getAttribute("disappear-trigger")
+      ? this.getAttribute("disappear-trigger").split(",")
+      : [];
+    this.triggerRootSelector = this.getAttribute("trigger-root");
 
-    this.consumer = await CableReady.consumer
+    this.consumer = await CableReady.consumer;
 
-    this.channel = this.createSubscription()
+    this.channel = this.createSubscription();
 
     this.mutationObserver = new MutationObserver((mutationsList, observer) => {
       if (this.triggerRootSelector) {
+        // eslint-disable-next-line no-unused-vars
         for (const mutation of mutationsList) {
-          const root = document.querySelector(this.triggerRootSelector)
+          const root = document.querySelector(this.triggerRootSelector);
           if (root) {
-            this.uninstall()
-            this.triggerRoot = root
-            this.install()
+            this.uninstall();
+            this.triggerRoot = root;
+            this.install();
           }
         }
       }
-      this.mutationObserver.disconnect()
-    })
+      this.mutationObserver.disconnect();
+    });
 
     this.mutationObserver.observe(document, {
       subtree: true,
-      childList: true
-    })
+      childList: true,
+    });
   }
 
-  disconnectedCallback () {
-    this.disappear()
-    super.disconnectedCallback()
+  disconnectedCallback() {
+    this.disappear();
+    super.disconnectedCallback();
   }
 
-  install () {
-    if (this.appearTriggers.includes('connect')) {
-      this.appear()
+  install() {
+    if (this.appearTriggers.includes("connect")) {
+      this.appear();
     }
 
     this.appearTriggers
-      .filter(eventName => eventName !== 'connect')
-      .forEach(eventName => {
-        this.triggerRoot.addEventListener(eventName, this.appear.bind(this))
-      })
+      .filter((eventName) => eventName !== "connect")
+      .forEach((eventName) => {
+        this.triggerRoot.addEventListener(eventName, this.appear.bind(this));
+      });
 
-    this.disappearTriggers.forEach(eventName => {
-      this.triggerRoot.addEventListener(eventName, this.disappear.bind(this))
-    })
+    this.disappearTriggers.forEach((eventName) => {
+      this.triggerRoot.addEventListener(eventName, this.disappear.bind(this));
+    });
   }
 
-  uninstall () {
+  uninstall() {
     this.appearTriggers
-      .filter(eventName => eventName !== 'connect')
-      .forEach(eventName => {
-        this.triggerRoot.removeEventListener(eventName, this.appear.bind(this))
-      })
+      .filter((eventName) => eventName !== "connect")
+      .forEach((eventName) => {
+        this.triggerRoot.removeEventListener(eventName, this.appear.bind(this));
+      });
 
-    this.disappearTriggers.forEach(eventName => {
-      this.triggerRoot.removeEventListener(eventName, this.disappear.bind(this))
-    })
+    this.disappearTriggers.forEach((eventName) => {
+      this.triggerRoot.removeEventListener(
+        eventName,
+        this.disappear.bind(this)
+      );
+    });
   }
 
-  appear () {
-    if (this.channel) this.channel.perform('appear')
+  appear() {
+    if (this.channel) this.channel.perform("appear");
   }
 
-  disappear () {
-    if (this.channel) this.channel.perform('disappear')
+  disappear() {
+    if (this.channel) this.channel.perform("disappear");
   }
 
-  performOperations (data) {
+  performOperations(data) {
     if (data.cableReady) {
-      CableReady.perform(data.operations)
+      CableReady.perform(data.operations);
     }
   }
 
-  createSubscription () {
+  createSubscription() {
     if (!this.consumer) {
       console.error(
-        'The `cubicle-element` helper cannot connect without an ActionCable consumer.'
-      )
-      return
+        "The `cubicle-element` helper cannot connect without an ActionCable consumer."
+      );
+      return;
     }
 
     return this.consumer.subscriptions.create(
       {
         channel: this.channelName,
-        identifier: this.getAttribute('identifier'),
-        user: this.getAttribute('user'),
+        identifier: this.getAttribute("identifier"),
+        user: this.getAttribute("user"),
         element_id: this.id,
         exclude_current_user:
-          this.getAttribute('exclude-current-user') === 'true'
+          this.getAttribute("exclude-current-user") === "true",
       },
       {
         connected: () => {
-          this.install()
+          this.install();
         },
         disconnected: () => {
-          this.disappear()
-          this.uninstall()
+          this.disappear();
+          this.uninstall();
         },
         rejected: () => {
-          this.uninstall()
+          this.uninstall();
         },
-        received: this.performOperations.bind(this)
+        received: this.performOperations.bind(this),
       }
-    )
+    );
   }
 
-  get channelName () {
-    return 'Cubism::PresenceChannel'
+  get channelName() {
+    return "Cubism::PresenceChannel";
   }
 }

--- a/javascript/elements/cubicle.js
+++ b/javascript/elements/cubicle.js
@@ -1,4 +1,5 @@
 import CableReady, { SubscribingElement } from "cable_ready";
+import { debounce } from "cable_ready/javascript/utils";
 
 export class Cubicle extends SubscribingElement {
   constructor() {
@@ -18,6 +19,8 @@ export class Cubicle extends SubscribingElement {
 
   async connectedCallback() {
     if (this.preview) return;
+
+    this.appear = debounce(this.appear.bind(this), 20);
 
     this.appearTriggers = this.getAttribute("appear-trigger")
       ? this.getAttribute("appear-trigger").split(",")


### PR DESCRIPTION
# Bug fix

## Description

Uses a `MutationObserver` to attach event listeners to elements as they appear. This is necessary because the `triggerRootSelector` might refer to elements that aren't yet present in the DOM when `connectedCallback` runs.

Fixes #7 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
