### PR TITLE
Scope elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ CableReady.initialize({ consumer });
 
 The `cubicle_for` helper accepts the following options as keyword arguments:
 
+- `scope`: declare a scope in which presence indicators should appear. For example, if you want to divide between index and show views, do `scope: :index` and `scope: :show` respectively (default: `""`).
 - `exclude_current_user (true|false)`: Whether or not to exclude the current user from the list of present users broadcasted to the view. Useful e.g. for "typing..." indicators (default: `true`).
 - `appear_trigger`: JavaScript event names (e.g. `["focus", "debounced:input]`) to use. (Can also be a singular string, which will be converted to an array). The default is `:connect`, i.e. register a user as "appeared"/"present" when the element connects to the DOM.
 - `disappear_trigger`: a JavaScript event name (e.g. `:blur`) to use. (Can also be a singular string, which will be converted to an array). The default is `:disconnect`, i.e. remove a user form the present users list when the element disconnects from the DOM.

--- a/app/channels/cubism/presence_channel.rb
+++ b/app/channels/cubism/presence_channel.rb
@@ -21,11 +21,11 @@ class Cubism::PresenceChannel < ActionCable::Channel::Base
   end
 
   def appear
-    resource.present_users[scope].add(user.id)
+    resource.set_present_users_for_scope(resource.present_users_for_scope(scope).add(user.id), scope)
   end
 
   def disappear
-    resource.present_users[scope].remove(user.id)
+    resource.set_present_users_for_scope(resource.present_users_for_scope(scope).delete(user.id), scope)
   end
 
   private

--- a/app/channels/cubism/presence_channel.rb
+++ b/app/channels/cubism/presence_channel.rb
@@ -52,6 +52,6 @@ class Cubism::PresenceChannel < ActionCable::Channel::Base
   end
 
   def scope
-    params[:scope] || ""
+    verified_stream_identifier(params[:scope]) || ""
   end
 end

--- a/app/channels/cubism/presence_channel.rb
+++ b/app/channels/cubism/presence_channel.rb
@@ -4,6 +4,7 @@ class Cubism::PresenceChannel < ActionCable::Channel::Base
   def subscribed
     if resource.present?
       stream_from params[:element_id]
+      resource.present_users[scope] ||= Set.new
       resource.cubicle_element_ids << element_id
       resource.excluded_user_id_for_element_id[element_id] = user.id if exclude_current_user?
     else
@@ -20,11 +21,11 @@ class Cubism::PresenceChannel < ActionCable::Channel::Base
   end
 
   def appear
-    resource.present_users.add(user.id)
+    resource.present_users[scope].add(user.id)
   end
 
   def disappear
-    resource.present_users.remove(user.id)
+    resource.present_users[scope].remove(user.id)
   end
 
   private
@@ -48,5 +49,9 @@ class Cubism::PresenceChannel < ActionCable::Channel::Base
 
   def url
     params[:url]
+  end
+
+  def scope
+    params[:scope] || ""
   end
 end

--- a/app/channels/cubism/presence_channel.rb
+++ b/app/channels/cubism/presence_channel.rb
@@ -4,7 +4,6 @@ class Cubism::PresenceChannel < ActionCable::Channel::Base
   def subscribed
     if resource.present?
       stream_from params[:element_id]
-      resource.present_users[scope] ||= Set.new
       resource.cubicle_element_ids << element_id
       resource.excluded_user_id_for_element_id[element_id] = user.id if exclude_current_user?
     else

--- a/app/helpers/cubism_helper.rb
+++ b/app/helpers/cubism_helper.rb
@@ -28,6 +28,7 @@ module CubismHelper
       "appear-trigger": Array(appear_trigger).join(","),
       "disappear-trigger": disappear_trigger,
       "trigger-root": trigger_root,
+      scope: signed_stream_identifier(scope),
       id: "cubicle-#{digested_block_key}",
       "exclude-current-user": exclude_current_user,
       **html_options

--- a/app/helpers/cubism_helper.rb
+++ b/app/helpers/cubism_helper.rb
@@ -1,7 +1,7 @@
 module CubismHelper
   include CableReady::StreamIdentifier
 
-  def cubicle_for(resource, user, scope: nil, html_options: {}, appear_trigger: :connect, disappear_trigger: nil, trigger_root: nil, exclude_current_user: true, &block)
+  def cubicle_for(resource, user, scope: "", html_options: {}, appear_trigger: :connect, disappear_trigger: nil, trigger_root: nil, exclude_current_user: true, &block)
     block_location = block.source_location.join(":")
     block_source = Cubism::BlockSource.find_or_create(
       location: block_location,

--- a/app/helpers/cubism_helper.rb
+++ b/app/helpers/cubism_helper.rb
@@ -1,7 +1,7 @@
 module CubismHelper
   include CableReady::StreamIdentifier
 
-  def cubicle_for(resource, user, html_options: {}, appear_trigger: :connect, disappear_trigger: nil, trigger_root: nil, exclude_current_user: true, &block)
+  def cubicle_for(resource, user, scope: nil, html_options: {}, appear_trigger: :connect, disappear_trigger: nil, trigger_root: nil, exclude_current_user: true, &block)
     block_location = block.source_location.join(":")
     block_source = Cubism::BlockSource.find_or_create(
       location: block_location,
@@ -14,7 +14,8 @@ module CubismHelper
       block_location: block_location,
       block_source: block_source,
       resource_gid: resource_gid,
-      user_gid: user.to_gid.to_s
+      user_gid: user.to_gid.to_s,
+      scope: scope
     )
 
     digested_block_key = block_container.digest

--- a/app/models/concerns/cubism/presence.rb
+++ b/app/models/concerns/cubism/presence.rb
@@ -11,6 +11,14 @@ module Cubism::Presence
     Cubism::Broadcaster.new(resource: self).broadcast
   end
 
+  def present_users_for_scope(scope = "")
+    present_users[scope].present? ? Marshal.load(present_users[scope]) : Set.new
+  end
+
+  def set_present_users_for_scope(user_ids, scope = "")
+    present_users[scope] = Marshal.dump(Set.new(user_ids))
+  end
+
   def present_users_for_element_id(element_id)
     users = Cubism.user_class.find(present_users.members)
     users.reject! { |user| user.id == excluded_user_id_for_element_id[element_id].to_i }

--- a/app/models/concerns/cubism/presence.rb
+++ b/app/models/concerns/cubism/presence.rb
@@ -2,7 +2,7 @@ module Cubism::Presence
   extend ActiveSupport::Concern
 
   included do
-    kredis_set :present_users, after_change: :stream_presence
+    kredis_hash :present_users, after_change: :stream_presence
     kredis_set :cubicle_element_ids
     kredis_hash :excluded_user_id_for_element_id
   end

--- a/app/models/concerns/cubism/presence.rb
+++ b/app/models/concerns/cubism/presence.rb
@@ -19,8 +19,8 @@ module Cubism::Presence
     present_users[scope] = Marshal.dump(Set.new(user_ids))
   end
 
-  def present_users_for_element_id(element_id)
-    users = Cubism.user_class.find(present_users.members)
+  def present_users_for_element_id_and_scope(element_id, scope = "")
+    users = Cubism.user_class.find(present_users_for_scope(scope).to_a)
     users.reject! { |user| user.id == excluded_user_id_for_element_id[element_id].to_i }
 
     users

--- a/javascript/elements/cubicle.js
+++ b/javascript/elements/cubicle.js
@@ -1,11 +1,11 @@
 /* eslint-disable no-undef */
-import CableReady, { SubscribingElement } from 'cable_ready'
-import { debounce } from 'cable_ready/javascript/utils'
+import CableReady, { SubscribingElement } from "cable_ready";
+import { debounce } from "cable_ready/javascript/utils";
 
 export class Cubicle extends SubscribingElement {
-  constructor () {
-    super()
-    const shadowRoot = this.attachShadow({ mode: 'open' })
+  constructor() {
+    super();
+    const shadowRoot = this.attachShadow({ mode: "open" });
     shadowRoot.innerHTML = `
 <style>
   :host {
@@ -13,130 +13,134 @@ export class Cubicle extends SubscribingElement {
   }
 </style>
 <slot></slot>
-`
+`;
 
-    this.triggerRoot = this
+    this.triggerRoot = this;
   }
 
-  async connectedCallback () {
-    if (this.preview) return
+  async connectedCallback() {
+    if (this.preview) return;
 
-    this.appear = debounce(this.appear.bind(this), 20)
+    this.appear = debounce(this.appear.bind(this), 20);
 
-    this.appearTriggers = this.getAttribute('appear-trigger')
-      ? this.getAttribute('appear-trigger').split(',')
-      : []
-    this.disappearTriggers = this.getAttribute('disappear-trigger')
-      ? this.getAttribute('disappear-trigger').split(',')
-      : []
-    this.triggerRootSelector = this.getAttribute('trigger-root')
+    this.appearTriggers = this.getAttribute("appear-trigger")
+      ? this.getAttribute("appear-trigger").split(",")
+      : [];
+    this.disappearTriggers = this.getAttribute("disappear-trigger")
+      ? this.getAttribute("disappear-trigger").split(",")
+      : [];
+    this.triggerRootSelector = this.getAttribute("trigger-root");
 
-    this.consumer = await CableReady.consumer
+    this.consumer = await CableReady.consumer;
 
-    this.channel = this.createSubscription()
+    this.channel = this.createSubscription();
 
     this.mutationObserver = new MutationObserver((mutationsList, observer) => {
       if (this.triggerRootSelector) {
         // eslint-disable-next-line no-unused-vars
         for (const mutation of mutationsList) {
-          const root = document.querySelector(this.triggerRootSelector)
+          const root = document.querySelector(this.triggerRootSelector);
           if (root) {
-            this.uninstall()
-            this.triggerRoot = root
-            this.install()
+            this.uninstall();
+            this.triggerRoot = root;
+            this.install();
           }
         }
       }
-      this.mutationObserver.disconnect()
-    })
+      this.mutationObserver.disconnect();
+    });
 
     this.mutationObserver.observe(document, {
       subtree: true,
-      childList: true
-    })
+      childList: true,
+    });
   }
 
-  disconnectedCallback () {
-    this.disappear()
-    super.disconnectedCallback()
+  disconnectedCallback() {
+    this.disappear();
+    super.disconnectedCallback();
   }
 
-  install () {
-    if (this.appearTriggers.includes('connect')) {
-      this.appear()
+  install() {
+    if (this.appearTriggers.includes("connect")) {
+      this.appear();
     }
 
     this.appearTriggers
-      .filter(eventName => eventName !== 'connect')
-      .forEach(eventName => {
-        this.triggerRoot.addEventListener(eventName, this.appear.bind(this))
-      })
+      .filter((eventName) => eventName !== "connect")
+      .forEach((eventName) => {
+        this.triggerRoot.addEventListener(eventName, this.appear.bind(this));
+      });
 
-    this.disappearTriggers.forEach(eventName => {
-      this.triggerRoot.addEventListener(eventName, this.disappear.bind(this))
-    })
+    this.disappearTriggers.forEach((eventName) => {
+      this.triggerRoot.addEventListener(eventName, this.disappear.bind(this));
+    });
   }
 
-  uninstall () {
+  uninstall() {
     this.appearTriggers
-      .filter(eventName => eventName !== 'connect')
-      .forEach(eventName => {
-        this.triggerRoot.removeEventListener(eventName, this.appear.bind(this))
-      })
+      .filter((eventName) => eventName !== "connect")
+      .forEach((eventName) => {
+        this.triggerRoot.removeEventListener(eventName, this.appear.bind(this));
+      });
 
-    this.disappearTriggers.forEach(eventName => {
-      this.triggerRoot.removeEventListener(eventName, this.disappear.bind(this))
-    })
+    this.disappearTriggers.forEach((eventName) => {
+      this.triggerRoot.removeEventListener(
+        eventName,
+        this.disappear.bind(this)
+      );
+    });
   }
 
-  appear () {
-    if (this.channel) this.channel.perform('appear')
+  appear() {
+    if (this.channel) this.channel.perform("appear");
   }
 
-  disappear () {
-    if (this.channel) this.channel.perform('disappear')
+  disappear() {
+    if (this.channel) this.channel.perform("disappear");
   }
 
-  performOperations (data) {
+  performOperations(data) {
     if (data.cableReady) {
-      CableReady.perform(data.operations)
+      CableReady.perform(data.operations);
     }
   }
 
-  createSubscription () {
+  createSubscription() {
     if (!this.consumer) {
       console.error(
-        'The `cubicle-element` helper cannot connect without an ActionCable consumer.'
-      )
-      return
+        "The `cubicle-element` helper cannot connect without an ActionCable consumer."
+      );
+      return;
     }
 
     return this.consumer.subscriptions.create(
       {
         channel: this.channelName,
-        identifier: this.getAttribute('identifier'),
-        user: this.getAttribute('user'),
+        identifier: this.getAttribute("identifier"),
+        user: this.getAttribute("user"),
         element_id: this.id,
+        scope: this.getAttribute("scope"),
         exclude_current_user:
-          this.getAttribute('exclude-current-user') === 'true'
+          this.getAttribute("exclude-current-user") === "true",
       },
       {
         connected: () => {
-          this.install()
+          this.install();
         },
         disconnected: () => {
-          this.disappear()
-          this.uninstall()
+          this.disappear();
+          this.uninstall();
         },
         rejected: () => {
-          this.uninstall()
+          this.uninstall();
         },
-        received: this.performOperations.bind(this)
+        received: this.performOperations.bind(this),
       }
-    )
+    );
   }
 
-  get channelName () {
-    return 'Cubism::PresenceChannel'
+  get channelName() {
+    return "Cubism::PresenceChannel";
   }
 }

--- a/javascript/elements/cubicle.js
+++ b/javascript/elements/cubicle.js
@@ -1,11 +1,11 @@
 /* eslint-disable no-undef */
-import CableReady, { SubscribingElement } from "cable_ready";
-import { debounce } from "cable_ready/javascript/utils";
+import CableReady, { SubscribingElement } from 'cable_ready'
+import { debounce } from 'cable_ready/javascript/utils'
 
 export class Cubicle extends SubscribingElement {
-  constructor() {
-    super();
-    const shadowRoot = this.attachShadow({ mode: "open" });
+  constructor () {
+    super()
+    const shadowRoot = this.attachShadow({ mode: 'open' })
     shadowRoot.innerHTML = `
 <style>
   :host {
@@ -13,133 +13,130 @@ export class Cubicle extends SubscribingElement {
   }
 </style>
 <slot></slot>
-`;
+`
 
-    this.triggerRoot = this;
+    this.triggerRoot = this
   }
 
-  async connectedCallback() {
-    if (this.preview) return;
+  async connectedCallback () {
+    if (this.preview) return
 
-    this.appear = debounce(this.appear.bind(this), 20);
+    this.appear = debounce(this.appear.bind(this), 20)
 
-    this.appearTriggers = this.getAttribute("appear-trigger")
-      ? this.getAttribute("appear-trigger").split(",")
-      : [];
-    this.disappearTriggers = this.getAttribute("disappear-trigger")
-      ? this.getAttribute("disappear-trigger").split(",")
-      : [];
-    this.triggerRootSelector = this.getAttribute("trigger-root");
+    this.appearTriggers = this.getAttribute('appear-trigger')
+      ? this.getAttribute('appear-trigger').split(',')
+      : []
+    this.disappearTriggers = this.getAttribute('disappear-trigger')
+      ? this.getAttribute('disappear-trigger').split(',')
+      : []
+    this.triggerRootSelector = this.getAttribute('trigger-root')
 
-    this.consumer = await CableReady.consumer;
+    this.consumer = await CableReady.consumer
 
-    this.channel = this.createSubscription();
+    this.channel = this.createSubscription()
 
     this.mutationObserver = new MutationObserver((mutationsList, observer) => {
       if (this.triggerRootSelector) {
         // eslint-disable-next-line no-unused-vars
         for (const mutation of mutationsList) {
-          const root = document.querySelector(this.triggerRootSelector);
+          const root = document.querySelector(this.triggerRootSelector)
           if (root) {
-            this.uninstall();
-            this.triggerRoot = root;
-            this.install();
+            this.uninstall()
+            this.triggerRoot = root
+            this.install()
           }
         }
       }
-      this.mutationObserver.disconnect();
-    });
+      this.mutationObserver.disconnect()
+    })
 
     this.mutationObserver.observe(document, {
       subtree: true,
-      childList: true,
-    });
+      childList: true
+    })
   }
 
-  disconnectedCallback() {
-    this.disappear();
-    super.disconnectedCallback();
+  disconnectedCallback () {
+    this.disappear()
+    super.disconnectedCallback()
   }
 
-  install() {
-    if (this.appearTriggers.includes("connect")) {
-      this.appear();
+  install () {
+    if (this.appearTriggers.includes('connect')) {
+      this.appear()
     }
 
     this.appearTriggers
-      .filter((eventName) => eventName !== "connect")
-      .forEach((eventName) => {
-        this.triggerRoot.addEventListener(eventName, this.appear.bind(this));
-      });
+      .filter(eventName => eventName !== 'connect')
+      .forEach(eventName => {
+        this.triggerRoot.addEventListener(eventName, this.appear.bind(this))
+      })
 
-    this.disappearTriggers.forEach((eventName) => {
-      this.triggerRoot.addEventListener(eventName, this.disappear.bind(this));
-    });
+    this.disappearTriggers.forEach(eventName => {
+      this.triggerRoot.addEventListener(eventName, this.disappear.bind(this))
+    })
   }
 
-  uninstall() {
+  uninstall () {
     this.appearTriggers
-      .filter((eventName) => eventName !== "connect")
-      .forEach((eventName) => {
-        this.triggerRoot.removeEventListener(eventName, this.appear.bind(this));
-      });
+      .filter(eventName => eventName !== 'connect')
+      .forEach(eventName => {
+        this.triggerRoot.removeEventListener(eventName, this.appear.bind(this))
+      })
 
-    this.disappearTriggers.forEach((eventName) => {
-      this.triggerRoot.removeEventListener(
-        eventName,
-        this.disappear.bind(this)
-      );
-    });
+    this.disappearTriggers.forEach(eventName => {
+      this.triggerRoot.removeEventListener(eventName, this.disappear.bind(this))
+    })
   }
 
-  appear() {
-    if (this.channel) this.channel.perform("appear");
+  appear () {
+    if (this.channel) this.channel.perform('appear')
   }
 
-  disappear() {
-    if (this.channel) this.channel.perform("disappear");
+  disappear () {
+    if (this.channel) this.channel.perform('disappear')
   }
 
-  performOperations(data) {
+  performOperations (data) {
     if (data.cableReady) {
-      CableReady.perform(data.operations);
+      CableReady.perform(data.operations)
     }
   }
 
-  createSubscription() {
+  createSubscription () {
     if (!this.consumer) {
       console.error(
-        "The `cubicle-element` helper cannot connect without an ActionCable consumer."
-      );
-      return;
+        'The `cubicle-element` helper cannot connect without an ActionCable consumer.'
+      )
+      return
     }
 
     return this.consumer.subscriptions.create(
       {
         channel: this.channelName,
-        identifier: this.getAttribute("identifier"),
-        user: this.getAttribute("user"),
+        identifier: this.getAttribute('identifier'),
+        user: this.getAttribute('user'),
         element_id: this.id,
         exclude_current_user:
-          this.getAttribute("exclude-current-user") === "true",
+          this.getAttribute('exclude-current-user') === 'true'
       },
       {
         connected: () => {
-          this.install();
+          this.install()
         },
         disconnected: () => {
-          this.disappear();
-          this.uninstall();
+          this.disappear()
+          this.uninstall()
         },
         rejected: () => {
-          this.uninstall();
+          this.uninstall()
         },
-        received: this.performOperations.bind(this),
+        received: this.performOperations.bind(this)
       }
-    );
+    )
   }
 
-  get channelName() {
-    return "Cubism::PresenceChannel";
+  get channelName () {
+    return 'Cubism::PresenceChannel'
   }
 }

--- a/lib/cubism/broadcaster.rb
+++ b/lib/cubism/broadcaster.rb
@@ -18,12 +18,18 @@ module Cubism
 
         next if block_container.blank?
 
+        present_users = resource.present_users_for_element_id_and_scope(element_id, block_container.scope)
+
+        next if present_users.empty?
+
         block_source = block_container.block_source
 
-        html = ApplicationController.render(inline: block_source.source, locals: {"#{block_source.variable_name}": resource.present_users_for_element_id(element_id)})
+        html = ApplicationController.render(inline: block_source.source, locals: {"#{block_source.variable_name}": present_users})
+
+        selector = "cubicle-element##{element_id}[identifier='#{signed_stream_identifier(resource.to_global_id.to_s)}'][scope='#{signed_stream_identifier(block_container.scope)}']"
 
         cable_ready[element_id].inner_html(
-          selector: "cubicle-element##{element_id}[identifier='#{signed_stream_identifier(resource.to_global_id.to_s)}']",
+          selector: selector,
           html: html
         ).broadcast
       end

--- a/lib/cubism/broadcaster.rb
+++ b/lib/cubism/broadcaster.rb
@@ -29,8 +29,10 @@ module Cubism
         cable_ready[element_id].inner_html(
           selector: selector,
           html: html
-        ).broadcast
+        )
       end
+
+      cable_ready.broadcast
     end
   end
 end

--- a/lib/cubism/broadcaster.rb
+++ b/lib/cubism/broadcaster.rb
@@ -20,8 +20,6 @@ module Cubism
 
         present_users = resource.present_users_for_element_id_and_scope(element_id, block_container.scope)
 
-        next if present_users.empty?
-
         block_source = block_container.block_source
 
         html = ApplicationController.render(inline: block_source.source, locals: {"#{block_source.variable_name}": present_users})

--- a/lib/cubism/cubicle_store.rb
+++ b/lib/cubism/cubicle_store.rb
@@ -49,6 +49,7 @@ module Cubism
     :block_source,
     :user_gid,
     :resource_gid,
+    :scope,
     keyword_init: true
   ) do
     def initialize(*args)
@@ -66,7 +67,7 @@ module Cubism
     end
 
     def digest
-      resource_user_key = [resource_gid, user_gid].join(":")
+      resource_user_key = [resource_gid, user_gid, scope].join(":")
 
       ActiveSupport::Digest.hexdigest("#{block_location}:#{File.read(@filename)}:#{resource_user_key}")
     end

--- a/lib/cubism/cubicle_store.rb
+++ b/lib/cubism/cubicle_store.rb
@@ -66,6 +66,10 @@ module Cubism
       GlobalID::Locator.locate self[:resource_gid]
     end
 
+    def scope
+      self[:scope] || ""
+    end
+
     def digest
       resource_user_key = [resource_gid, user_gid, scope].join(":")
 

--- a/lib/cubism/cubicle_store.rb
+++ b/lib/cubism/cubicle_store.rb
@@ -71,7 +71,7 @@ module Cubism
     end
 
     def digest
-      resource_user_key = [resource_gid, user_gid, scope].join(":")
+      resource_user_key = [resource_gid, user_gid].join(":")
 
       ActiveSupport::Digest.hexdigest("#{block_location}:#{File.read(@filename)}:#{resource_user_key}")
     end

--- a/test/broadcaster_test.rb
+++ b/test/broadcaster_test.rb
@@ -6,46 +6,62 @@ class BroadcasterTest < ActionView::TestCase
   setup do
     @post = posts(:one)
     @post.stubs(:cubicle_element_ids).returns(%w[cubicle-foo cubicle-bar])
-    @post.stubs(:present_users_for_element_id).with("cubicle-foo").returns([users(:one)])
-    @post.stubs(:present_users_for_element_id).with("cubicle-bar").returns([users(:two)])
-    @broadcaster = Cubism::Broadcaster.new(resource: @post)
+    @post.stubs(:present_users_for_element_id_and_scope).with("cubicle-foo", "").returns([users(:one)])
+    @post.stubs(:present_users_for_element_id_and_scope).with("cubicle-bar", "").returns([users(:two)])
+
+    @post_2 = posts(:two)
+    @post_2.stubs(:cubicle_element_ids).returns(%w[cubicle-baz])
+    @post_2.stubs(:present_users_for_element_id_and_scope).with("cubicle-baz", :edit).returns([users(:one)])
+    @post_2.stubs(:present_users_for_element_id_and_scope).with("cubicle-baz", :show).returns([])
+
     block_source_foo = Cubism::BlockSource.new(location: "test:1", variable_name: "users", source: "<div><%= users.map(&:username).to_sentence %></div>", view_context: self)
     block_source_bar = Cubism::BlockSource.new(location: "test:1", variable_name: "present_users", source: "<div><%= present_users.map(&:username).to_sentence %></div>", view_context: self)
 
     Cubism.stubs(:block_store).returns({
       "foo" => Cubism::BlockContainer.new(block_location: "test:1", block_source: block_source_foo, user_gid: users(:one).to_gid.to_s, resource_gid: posts(:one).to_gid.to_s),
-      "bar" => Cubism::BlockContainer.new(block_location: "test:1", block_source: block_source_bar, user_gid: users(:two).to_gid.to_s, resource_gid: posts(:one).to_gid.to_s)
+      "bar" => Cubism::BlockContainer.new(block_location: "test:1", block_source: block_source_bar, user_gid: users(:two).to_gid.to_s, resource_gid: posts(:one).to_gid.to_s),
+      "baz" => Cubism::BlockContainer.new(block_location: "test:1", block_source: block_source_foo, user_gid: users(:one).to_gid.to_s, resource_gid: posts(:two).to_gid.to_s, scope: :edit)
     })
   end
 
-  test "it broadcasts to all registered element ids" do
-    with_mocked_cable_ready({"cubicle-foo" => users(:one), "cubicle-bar" => users(:two)}, @post) do |cable_ready_mock|
-      members = Set[]
-      members.stubs(:members).returns([users(:one).id, users(:two).id])
-      @post.stubs(:present_users).returns(members)
+  test "it broadcasts to all registered element ids with default scopes" do
+    with_mocked_cable_ready({"cubicle-foo" => {"" => users(:one)}, "cubicle-bar" => {"" => users(:two)}}, @post) do |cable_ready_mock|
+      @broadcaster = Cubism::Broadcaster.new(resource: @post)
 
       @broadcaster.expects(:cable_ready).returns(cable_ready_mock).twice
 
       @broadcaster.broadcast
     end
   end
+
+  test "it broadcasts to all registered element ids and respects scopes" do
+    with_mocked_cable_ready({"cubicle-baz" => {"edit" => users(:one)}}, @post_2) do |cable_ready_mock|
+      @broadcaster = Cubism::Broadcaster.new(resource: @post_2)
+
+      @broadcaster.expects(:cable_ready).returns(cable_ready_mock).once
+
+      @broadcaster.broadcast
+    end
+  end
 end
 
-def with_mocked_cable_ready(elements_with_users, resource)
+def with_mocked_cable_ready(elements_with_users_and_scopes, resource)
   operation_mock = mock
-  operation_mock.expects(:broadcast).times(elements_with_users.size)
+  operation_mock.expects(:broadcast).times(elements_with_users_and_scopes.keys.size)
 
   cable_ready_mock = mock
 
-  elements_with_users.each do |element_id, user|
+  elements_with_users_and_scopes.each do |element_id, scoped_users|
     cable_ready_channel = mock
-    cable_ready_channel
-      .expects(:inner_html)
-      .with({
-        selector: "cubicle-element##{element_id}[identifier='#{signed_stream_identifier(resource.to_global_id.to_s)}']",
-        html: "<div>#{user.username}</div>"
-      })
-      .returns(operation_mock)
+    scoped_users.each do |scope, user|
+      cable_ready_channel
+        .expects(:inner_html)
+        .with({
+          selector: "cubicle-element##{element_id}[identifier='#{signed_stream_identifier(resource.to_global_id.to_s)}'][scope='#{signed_stream_identifier(scope)}']",
+          html: "<div>#{user.username}</div>"
+        })
+        .returns(operation_mock)
+    end
     cable_ready_mock.expects(:[]).with(element_id).returns(cable_ready_channel)
   end
 

--- a/test/broadcaster_test.rb
+++ b/test/broadcaster_test.rb
@@ -28,7 +28,7 @@ class BroadcasterTest < ActionView::TestCase
     with_mocked_cable_ready({"cubicle-foo" => {"" => users(:one)}, "cubicle-bar" => {"" => users(:two)}}, @post) do |cable_ready_mock|
       @broadcaster = Cubism::Broadcaster.new(resource: @post)
 
-      @broadcaster.expects(:cable_ready).returns(cable_ready_mock).twice
+      @broadcaster.expects(:cable_ready).returns(cable_ready_mock).times(3)
 
       @broadcaster.broadcast
     end
@@ -38,7 +38,7 @@ class BroadcasterTest < ActionView::TestCase
     with_mocked_cable_ready({"cubicle-baz" => {"edit" => users(:one)}}, @post_2) do |cable_ready_mock|
       @broadcaster = Cubism::Broadcaster.new(resource: @post_2)
 
-      @broadcaster.expects(:cable_ready).returns(cable_ready_mock).once
+      @broadcaster.expects(:cable_ready).returns(cable_ready_mock).twice
 
       @broadcaster.broadcast
     end
@@ -46,10 +46,8 @@ class BroadcasterTest < ActionView::TestCase
 end
 
 def with_mocked_cable_ready(elements_with_users_and_scopes, resource)
-  operation_mock = mock
-  operation_mock.expects(:broadcast).times(elements_with_users_and_scopes.keys.size)
-
   cable_ready_mock = mock
+  cable_ready_mock.expects(:broadcast).once
 
   elements_with_users_and_scopes.each do |element_id, scoped_users|
     cable_ready_channel = mock
@@ -60,7 +58,6 @@ def with_mocked_cable_ready(elements_with_users_and_scopes, resource)
           selector: "cubicle-element##{element_id}[identifier='#{signed_stream_identifier(resource.to_global_id.to_s)}'][scope='#{signed_stream_identifier(scope)}']",
           html: "<div>#{user.username}</div>"
         })
-        .returns(operation_mock)
     end
     cable_ready_mock.expects(:[]).with(element_id).returns(cable_ready_channel)
   end

--- a/test/channels/cubism/presence_channel_test.rb
+++ b/test/channels/cubism/presence_channel_test.rb
@@ -9,7 +9,7 @@ class Cubism::PresenceChannelTest < ActionCable::Channel::TestCase
 
     Post.any_instance.stubs(:cubicle_element_ids).returns([])
     Post.any_instance.stubs(:excluded_user_id_for_element_id).returns({})
-    Post.any_instance.stubs(:present_users).returns(Set[])
+    Post.any_instance.stubs(:present_users).returns({})
   end
 
   test "rejects a subscription for invalid identifiers" do
@@ -35,18 +35,27 @@ class Cubism::PresenceChannelTest < ActionCable::Channel::TestCase
 
   test "adds a user to the present users list when appear is called" do
     subscribe identifier: signed_stream_identifier(@post.to_gid.to_s), user: @user.to_sgid.to_s, element_id: "bar"
-
     perform :appear
 
-    assert_equal [@user.id], @post.present_users.to_a
+    assert_equal [@user.id], @post.present_users[""].to_a
   end
 
-  test "removes a user from the present users list when appear is called" do
+  test "adds a user to a scope in the present users list when appear is called with a scope parameter" do
+    subscribe identifier: signed_stream_identifier(@post.to_gid.to_s), user: @user.to_sgid.to_s, element_id: "bar", scope: :edit
+    perform :appear
+
+    subscribe identifier: signed_stream_identifier(@post.to_gid.to_s), user: @user.to_sgid.to_s, element_id: "bar", scope: :show
+
+    assert_equal [@user.id], @post.present_users[:edit].to_a
+    assert_equal [], @post.present_users[:show].to_a
+  end
+
+  test "removes a user from the present users list when disappear is called" do
     subscribe identifier: signed_stream_identifier(@post.to_gid.to_s), user: @user.to_sgid.to_s, element_id: "bar"
 
     perform :appear
 
-    assert_equal [@user.id], @post.present_users.to_a
+    assert_equal [@user.id], @post.present_users[""].to_a
 
     # perform :disappear
 

--- a/test/channels/cubism/presence_channel_test.rb
+++ b/test/channels/cubism/presence_channel_test.rb
@@ -41,16 +41,16 @@ class Cubism::PresenceChannelTest < ActionCable::Channel::TestCase
   end
 
   test "adds a user to a scope in the present users list when appear is called with a scope parameter" do
-    assert_equal [], @post.present_users_for_scope(:edit).to_a
-    assert_equal [], @post.present_users_for_scope(:show).to_a
+    assert_equal [], @post.present_users_for_scope("edit").to_a
+    assert_equal [], @post.present_users_for_scope("show").to_a
 
-    subscribe identifier: signed_stream_identifier(@post.to_gid.to_s), user: @user.to_sgid.to_s, element_id: "bar", scope: :edit
+    subscribe identifier: signed_stream_identifier(@post.to_gid.to_s), user: @user.to_sgid.to_s, element_id: "bar", scope: signed_stream_identifier("edit")
     perform :appear
 
-    subscribe identifier: signed_stream_identifier(@post.to_gid.to_s), user: @user.to_sgid.to_s, element_id: "bar", scope: :show
+    subscribe identifier: signed_stream_identifier(@post.to_gid.to_s), user: @user.to_sgid.to_s, element_id: "bar", scope: signed_stream_identifier("show")
 
-    assert_equal [@user.id], @post.present_users_for_scope(:edit).to_a
-    assert_equal [], @post.present_users_for_scope(:show).to_a
+    assert_equal [@user.id], @post.present_users_for_scope("edit").to_a
+    assert_equal [], @post.present_users_for_scope("show").to_a
   end
 
   test "removes a user from the present users list when disappear is called" do

--- a/test/channels/cubism/presence_channel_test.rb
+++ b/test/channels/cubism/presence_channel_test.rb
@@ -37,17 +37,20 @@ class Cubism::PresenceChannelTest < ActionCable::Channel::TestCase
     subscribe identifier: signed_stream_identifier(@post.to_gid.to_s), user: @user.to_sgid.to_s, element_id: "bar"
     perform :appear
 
-    assert_equal [@user.id], @post.present_users[""].to_a
+    assert_equal [@user.id], @post.present_users_for_scope("").to_a
   end
 
   test "adds a user to a scope in the present users list when appear is called with a scope parameter" do
+    assert_equal [], @post.present_users_for_scope(:edit).to_a
+    assert_equal [], @post.present_users_for_scope(:show).to_a
+
     subscribe identifier: signed_stream_identifier(@post.to_gid.to_s), user: @user.to_sgid.to_s, element_id: "bar", scope: :edit
     perform :appear
 
     subscribe identifier: signed_stream_identifier(@post.to_gid.to_s), user: @user.to_sgid.to_s, element_id: "bar", scope: :show
 
-    assert_equal [@user.id], @post.present_users[:edit].to_a
-    assert_equal [], @post.present_users[:show].to_a
+    assert_equal [@user.id], @post.present_users_for_scope(:edit).to_a
+    assert_equal [], @post.present_users_for_scope(:show).to_a
   end
 
   test "removes a user from the present users list when disappear is called" do
@@ -55,10 +58,10 @@ class Cubism::PresenceChannelTest < ActionCable::Channel::TestCase
 
     perform :appear
 
-    assert_equal [@user.id], @post.present_users[""].to_a
+    assert_equal [@user.id], @post.present_users_for_scope("").to_a
 
-    # perform :disappear
+    perform :disappear
 
-    # assert_equal [], @post.present_users.to_a
+    assert_equal [], @post.present_users_for_scope("").to_a
   end
 end

--- a/test/models/concerns/presence_test.rb
+++ b/test/models/concerns/presence_test.rb
@@ -2,16 +2,24 @@ require "test_helper"
 
 class Cubism::PresenceTest < ActiveSupport::TestCase
   setup do
-    members = Set[]
-    members.stubs(:members).returns([users(:one).id, users(:two).id])
+    scoped_present_users = {
+      "" => Marshal.dump(Set.new([users(:one).id, users(:two).id])),
+      :edit => Marshal.dump(Set.new([users(:one).id])),
+      :show => Marshal.dump(Set.new([users(:two).id]))
+    }
 
     @post = posts(:one)
-    @post.stubs(:present_users).returns(members)
+    @post.stubs(:present_users).returns(scoped_present_users)
     @post.stubs(:excluded_user_id_for_element_id).returns({"foo" => users(:one).id, "bar" => users(:two).id})
   end
 
   test "Cubism::Presence respects excluded users per element" do
-    assert_equal [users(:two)], @post.present_users_for_element_id("foo")
-    assert_equal [users(:one)], @post.present_users_for_element_id("bar")
+    assert_equal [users(:two)], @post.present_users_for_element_id_and_scope("foo")
+    assert_equal [users(:one)], @post.present_users_for_element_id_and_scope("bar")
+  end
+
+  test "Cubism::Presence respects scopes along with excluded users" do
+    assert_equal [users(:one)], @post.present_users_for_element_id_and_scope("bar", :edit)
+    assert_equal [], @post.present_users_for_element_id_and_scope("bar", :show)
   end
 end


### PR DESCRIPTION
# Enhancement

## Description
Introduces the capability to scope `cubicles` to a certain scope `key`.

Without this addition, presence indicators would appear on irrelevant views, whenever a matching `identifier` was found (i.e., the resource was the same). This can be confusing because a user might be editing the same resource, but might be on a completely different page.

With this PR, you can do `cubicle_for resource, user, scope: :edit ...` for example, thus scoping broadcasts with a higher specifity