### PR TITLE
Fix scoping

### DIFF
--- a/app/channels/cubism/presence_channel.rb
+++ b/app/channels/cubism/presence_channel.rb
@@ -3,7 +3,7 @@ class Cubism::PresenceChannel < ActionCable::Channel::Base
 
   def subscribed
     if resource.present?
-      stream_from params[:element_id]
+      stream_from element_id
       resource.cubicle_element_ids << element_id
       resource.excluded_user_id_for_element_id[element_id] = user.id if exclude_current_user?
     else
@@ -35,7 +35,15 @@ class Cubism::PresenceChannel < ActionCable::Channel::Base
   end
 
   def user
-    GlobalID::Locator.locate_signed(params[:user])
+    block_container.user
+  end
+
+  def scope
+    block_container.scope
+  end
+
+  def block_container
+    Cubism.block_store[element_id]
   end
 
   def exclude_current_user?
@@ -43,14 +51,11 @@ class Cubism::PresenceChannel < ActionCable::Channel::Base
   end
 
   def element_id
-    params[:element_id]
+    /cubicle-(?<element_id>.+)/ =~ params[:element_id]
+    element_id
   end
 
   def url
     params[:url]
-  end
-
-  def scope
-    params[:scope] || ""
   end
 end

--- a/app/channels/cubism/presence_channel.rb
+++ b/app/channels/cubism/presence_channel.rb
@@ -51,6 +51,6 @@ class Cubism::PresenceChannel < ActionCable::Channel::Base
   end
 
   def scope
-    verified_stream_identifier(params[:scope]) || ""
+    params[:scope] || ""
   end
 end

--- a/app/helpers/cubism_helper.rb
+++ b/app/helpers/cubism_helper.rb
@@ -24,7 +24,6 @@ module CubismHelper
 
     tag.cubicle_element(
       identifier: signed_stream_identifier(resource_gid),
-      user: user.to_sgid.to_s,
       "appear-trigger": Array(appear_trigger).join(","),
       "disappear-trigger": disappear_trigger,
       "trigger-root": trigger_root,

--- a/app/helpers/cubism_helper.rb
+++ b/app/helpers/cubism_helper.rb
@@ -28,7 +28,7 @@ module CubismHelper
       "appear-trigger": Array(appear_trigger).join(","),
       "disappear-trigger": disappear_trigger,
       "trigger-root": trigger_root,
-      scope: signed_stream_identifier(scope),
+      scope: scope,
       id: "cubicle-#{digested_block_key}",
       "exclude-current-user": exclude_current_user,
       **html_options

--- a/javascript/elements/cubicle.js
+++ b/javascript/elements/cubicle.js
@@ -118,7 +118,6 @@ export class Cubicle extends SubscribingElement {
       {
         channel: this.channelName,
         identifier: this.getAttribute("identifier"),
-        user: this.getAttribute("user"),
         element_id: this.id,
         scope: this.getAttribute("scope"),
         exclude_current_user:

--- a/javascript/elements/cubicle.js
+++ b/javascript/elements/cubicle.js
@@ -1,11 +1,11 @@
 /* eslint-disable no-undef */
-import CableReady, { SubscribingElement } from "cable_ready";
-import { debounce } from "cable_ready/javascript/utils";
+import CableReady, { SubscribingElement } from 'cable_ready'
+import { debounce } from 'cable_ready/javascript/utils'
 
 export class Cubicle extends SubscribingElement {
-  constructor() {
-    super();
-    const shadowRoot = this.attachShadow({ mode: "open" });
+  constructor () {
+    super()
+    const shadowRoot = this.attachShadow({ mode: 'open' })
     shadowRoot.innerHTML = `
 <style>
   :host {
@@ -13,133 +13,130 @@ export class Cubicle extends SubscribingElement {
   }
 </style>
 <slot></slot>
-`;
+`
 
-    this.triggerRoot = this;
+    this.triggerRoot = this
   }
 
-  async connectedCallback() {
-    if (this.preview) return;
+  async connectedCallback () {
+    if (this.preview) return
 
-    this.appear = debounce(this.appear.bind(this), 20);
+    this.appear = debounce(this.appear.bind(this), 20)
 
-    this.appearTriggers = this.getAttribute("appear-trigger")
-      ? this.getAttribute("appear-trigger").split(",")
-      : [];
-    this.disappearTriggers = this.getAttribute("disappear-trigger")
-      ? this.getAttribute("disappear-trigger").split(",")
-      : [];
-    this.triggerRootSelector = this.getAttribute("trigger-root");
+    this.appearTriggers = this.getAttribute('appear-trigger')
+      ? this.getAttribute('appear-trigger').split(',')
+      : []
+    this.disappearTriggers = this.getAttribute('disappear-trigger')
+      ? this.getAttribute('disappear-trigger').split(',')
+      : []
+    this.triggerRootSelector = this.getAttribute('trigger-root')
 
-    this.consumer = await CableReady.consumer;
+    this.consumer = await CableReady.consumer
 
-    this.channel = this.createSubscription();
+    this.channel = this.createSubscription()
 
     this.mutationObserver = new MutationObserver((mutationsList, observer) => {
       if (this.triggerRootSelector) {
         // eslint-disable-next-line no-unused-vars
         for (const mutation of mutationsList) {
-          const root = document.querySelector(this.triggerRootSelector);
+          const root = document.querySelector(this.triggerRootSelector)
           if (root) {
-            this.uninstall();
-            this.triggerRoot = root;
-            this.install();
+            this.uninstall()
+            this.triggerRoot = root
+            this.install()
           }
         }
       }
-      this.mutationObserver.disconnect();
-    });
+      this.mutationObserver.disconnect()
+    })
 
     this.mutationObserver.observe(document, {
       subtree: true,
-      childList: true,
-    });
+      childList: true
+    })
   }
 
-  disconnectedCallback() {
-    this.disappear();
-    super.disconnectedCallback();
+  disconnectedCallback () {
+    this.disappear()
+    super.disconnectedCallback()
   }
 
-  install() {
-    if (this.appearTriggers.includes("connect")) {
-      this.appear();
+  install () {
+    if (this.appearTriggers.includes('connect')) {
+      this.appear()
     }
 
     this.appearTriggers
-      .filter((eventName) => eventName !== "connect")
-      .forEach((eventName) => {
-        this.triggerRoot.addEventListener(eventName, this.appear.bind(this));
-      });
+      .filter(eventName => eventName !== 'connect')
+      .forEach(eventName => {
+        this.triggerRoot.addEventListener(eventName, this.appear.bind(this))
+      })
 
-    this.disappearTriggers.forEach((eventName) => {
-      this.triggerRoot.addEventListener(eventName, this.disappear.bind(this));
-    });
+    this.disappearTriggers.forEach(eventName => {
+      this.triggerRoot.addEventListener(eventName, this.disappear.bind(this))
+    })
   }
 
-  uninstall() {
+  uninstall () {
     this.appearTriggers
-      .filter((eventName) => eventName !== "connect")
-      .forEach((eventName) => {
-        this.triggerRoot.removeEventListener(eventName, this.appear.bind(this));
-      });
+      .filter(eventName => eventName !== 'connect')
+      .forEach(eventName => {
+        this.triggerRoot.removeEventListener(eventName, this.appear.bind(this))
+      })
 
-    this.disappearTriggers.forEach((eventName) => {
-      this.triggerRoot.removeEventListener(
-        eventName,
-        this.disappear.bind(this)
-      );
-    });
+    this.disappearTriggers.forEach(eventName => {
+      this.triggerRoot.removeEventListener(eventName, this.disappear.bind(this))
+    })
   }
 
-  appear() {
-    if (this.channel) this.channel.perform("appear");
+  appear () {
+    if (this.channel) this.channel.perform('appear')
   }
 
-  disappear() {
-    if (this.channel) this.channel.perform("disappear");
+  disappear () {
+    if (this.channel) this.channel.perform('disappear')
   }
 
-  performOperations(data) {
+  performOperations (data) {
     if (data.cableReady) {
-      CableReady.perform(data.operations);
+      CableReady.perform(data.operations)
     }
   }
 
-  createSubscription() {
+  createSubscription () {
     if (!this.consumer) {
       console.error(
-        "The `cubicle-element` helper cannot connect without an ActionCable consumer."
-      );
-      return;
+        'The `cubicle-element` helper cannot connect without an ActionCable consumer.'
+      )
+      return
     }
 
     return this.consumer.subscriptions.create(
       {
         channel: this.channelName,
-        identifier: this.getAttribute("identifier"),
+        identifier: this.getAttribute('identifier'),
         element_id: this.id,
-        scope: this.getAttribute("scope"),
+        scope: this.getAttribute('scope'),
         exclude_current_user:
-          this.getAttribute("exclude-current-user") === "true",
+          this.getAttribute('exclude-current-user') === 'true'
       },
       {
         connected: () => {
-          this.install();
+          this.install()
         },
         disconnected: () => {
-          this.disappear();
-          this.uninstall();
+          this.disappear()
+          this.uninstall()
         },
         rejected: () => {
-          this.uninstall();
+          this.uninstall()
         },
-        received: this.performOperations.bind(this),
+        received: this.performOperations.bind(this)
       }
-    );
+    )
   }
 
-  get channelName() {
-    return "Cubism::PresenceChannel";
+  get channelName () {
+    return 'Cubism::PresenceChannel'
   }
 }

--- a/lib/cubism/broadcaster.rb
+++ b/lib/cubism/broadcaster.rb
@@ -13,8 +13,7 @@ module Cubism
 
     def broadcast
       resource.cubicle_element_ids.to_a.each do |element_id|
-        /cubicle-(?<block_key>.+)/ =~ element_id
-        block_container = Cubism.block_store[block_key]
+        block_container = Cubism.block_store[element_id]
 
         next if block_container.blank?
 
@@ -24,7 +23,7 @@ module Cubism
 
         html = ApplicationController.render(inline: block_source.source, locals: {"#{block_source.variable_name}": present_users})
 
-        selector = "cubicle-element##{element_id}[identifier='#{signed_stream_identifier(resource.to_global_id.to_s)}'][scope='#{block_container.scope}']"
+        selector = "cubicle-element#cubicle-#{element_id}[identifier='#{signed_stream_identifier(resource.to_global_id.to_s)}'][scope='#{block_container.scope}']"
 
         cable_ready[element_id].inner_html(
           selector: selector,

--- a/lib/cubism/broadcaster.rb
+++ b/lib/cubism/broadcaster.rb
@@ -24,7 +24,7 @@ module Cubism
 
         html = ApplicationController.render(inline: block_source.source, locals: {"#{block_source.variable_name}": present_users})
 
-        selector = "cubicle-element##{element_id}[identifier='#{signed_stream_identifier(resource.to_global_id.to_s)}'][scope='#{signed_stream_identifier(block_container.scope)}']"
+        selector = "cubicle-element##{element_id}[identifier='#{signed_stream_identifier(resource.to_global_id.to_s)}'][scope='#{block_container.scope}']"
 
         cable_ready[element_id].inner_html(
           selector: selector,

--- a/lib/cubism/cubicle_store.rb
+++ b/lib/cubism/cubicle_store.rb
@@ -71,7 +71,7 @@ module Cubism
     end
 
     def digest
-      resource_user_key = [resource_gid, user_gid].join(":")
+      resource_user_key = [resource_gid, user_gid, scope].join(":")
 
       ActiveSupport::Digest.hexdigest("#{block_location}:#{File.read(@filename)}:#{resource_user_key}")
     end

--- a/test/broadcaster_test.rb
+++ b/test/broadcaster_test.rb
@@ -5,14 +5,14 @@ class BroadcasterTest < ActionView::TestCase
 
   setup do
     @post = posts(:one)
-    @post.stubs(:cubicle_element_ids).returns(%w[cubicle-foo cubicle-bar])
-    @post.stubs(:present_users_for_element_id_and_scope).with("cubicle-foo", "").returns([users(:one)])
-    @post.stubs(:present_users_for_element_id_and_scope).with("cubicle-bar", "").returns([users(:two)])
+    @post.stubs(:cubicle_element_ids).returns(%w[foo bar])
+    @post.stubs(:present_users_for_element_id_and_scope).with("foo", "").returns([users(:one)])
+    @post.stubs(:present_users_for_element_id_and_scope).with("bar", "").returns([users(:two)])
 
     @post_2 = posts(:two)
-    @post_2.stubs(:cubicle_element_ids).returns(%w[cubicle-baz])
-    @post_2.stubs(:present_users_for_element_id_and_scope).with("cubicle-baz", :edit).returns([users(:one)])
-    @post_2.stubs(:present_users_for_element_id_and_scope).with("cubicle-baz", :show).returns([])
+    @post_2.stubs(:cubicle_element_ids).returns(%w[baz])
+    @post_2.stubs(:present_users_for_element_id_and_scope).with("baz", :edit).returns([users(:one)])
+    @post_2.stubs(:present_users_for_element_id_and_scope).with("baz", :show).returns([])
 
     block_source_foo = Cubism::BlockSource.new(location: "test:1", variable_name: "users", source: "<div><%= users.map(&:username).to_sentence %></div>", view_context: self)
     block_source_bar = Cubism::BlockSource.new(location: "test:1", variable_name: "present_users", source: "<div><%= present_users.map(&:username).to_sentence %></div>", view_context: self)
@@ -25,7 +25,7 @@ class BroadcasterTest < ActionView::TestCase
   end
 
   test "it broadcasts to all registered element ids with default scopes" do
-    with_mocked_cable_ready({"cubicle-foo" => {"" => users(:one)}, "cubicle-bar" => {"" => users(:two)}}, @post) do |cable_ready_mock|
+    with_mocked_cable_ready({"foo" => {"" => users(:one)}, "bar" => {"" => users(:two)}}, @post) do |cable_ready_mock|
       @broadcaster = Cubism::Broadcaster.new(resource: @post)
 
       @broadcaster.expects(:cable_ready).returns(cable_ready_mock).times(3)
@@ -35,7 +35,7 @@ class BroadcasterTest < ActionView::TestCase
   end
 
   test "it broadcasts to all registered element ids and respects scopes" do
-    with_mocked_cable_ready({"cubicle-baz" => {"edit" => users(:one)}}, @post_2) do |cable_ready_mock|
+    with_mocked_cable_ready({"baz" => {"edit" => users(:one)}}, @post_2) do |cable_ready_mock|
       @broadcaster = Cubism::Broadcaster.new(resource: @post_2)
 
       @broadcaster.expects(:cable_ready).returns(cable_ready_mock).twice
@@ -55,7 +55,7 @@ def with_mocked_cable_ready(elements_with_users_and_scopes, resource)
       cable_ready_channel
         .expects(:inner_html)
         .with({
-          selector: "cubicle-element##{element_id}[identifier='#{signed_stream_identifier(resource.to_global_id.to_s)}'][scope='#{scope}']",
+          selector: "cubicle-element#cubicle-#{element_id}[identifier='#{signed_stream_identifier(resource.to_global_id.to_s)}'][scope='#{scope}']",
           html: "<div>#{user.username}</div>"
         })
     end

--- a/test/broadcaster_test.rb
+++ b/test/broadcaster_test.rb
@@ -55,7 +55,7 @@ def with_mocked_cable_ready(elements_with_users_and_scopes, resource)
       cable_ready_channel
         .expects(:inner_html)
         .with({
-          selector: "cubicle-element##{element_id}[identifier='#{signed_stream_identifier(resource.to_global_id.to_s)}'][scope='#{signed_stream_identifier(scope)}']",
+          selector: "cubicle-element##{element_id}[identifier='#{signed_stream_identifier(resource.to_global_id.to_s)}'][scope='#{scope}']",
           html: "<div>#{user.username}</div>"
         })
     end

--- a/test/channels/cubism/presence_channel_test.rb
+++ b/test/channels/cubism/presence_channel_test.rb
@@ -44,10 +44,10 @@ class Cubism::PresenceChannelTest < ActionCable::Channel::TestCase
     assert_equal [], @post.present_users_for_scope("edit").to_a
     assert_equal [], @post.present_users_for_scope("show").to_a
 
-    subscribe identifier: signed_stream_identifier(@post.to_gid.to_s), user: @user.to_sgid.to_s, element_id: "bar", scope: signed_stream_identifier("edit")
+    subscribe identifier: signed_stream_identifier(@post.to_gid.to_s), user: @user.to_sgid.to_s, element_id: "bar", scope: "edit"
     perform :appear
 
-    subscribe identifier: signed_stream_identifier(@post.to_gid.to_s), user: @user.to_sgid.to_s, element_id: "bar", scope: signed_stream_identifier("show")
+    subscribe identifier: signed_stream_identifier(@post.to_gid.to_s), user: @user.to_sgid.to_s, element_id: "bar", scope: "show"
 
     assert_equal [@user.id], @post.present_users_for_scope("edit").to_a
     assert_equal [], @post.present_users_for_scope("show").to_a

--- a/test/channels/cubism/presence_channel_test.rb
+++ b/test/channels/cubism/presence_channel_test.rb
@@ -10,16 +10,21 @@ class Cubism::PresenceChannelTest < ActionCable::Channel::TestCase
     Post.any_instance.stubs(:cubicle_element_ids).returns([])
     Post.any_instance.stubs(:excluded_user_id_for_element_id).returns({})
     Post.any_instance.stubs(:present_users).returns({})
+
+    Cubism.stubs(:block_store).returns({
+      "foo" => Cubism::BlockContainer.new(block_location: "test:1", user_gid: @user.to_gid.to_s, resource_gid: @post.to_gid.to_s, scope: ""),
+      "bar" => Cubism::BlockContainer.new(block_location: "test:1", user_gid: @user.to_gid.to_s, resource_gid: @post.to_gid.to_s, scope: "edit")
+    })
   end
 
   test "rejects a subscription for invalid identifiers" do
-    subscribe identifier: "foo", element_id: "bar"
+    subscribe identifier: "foo", element_id: "cubicle-bar"
 
     assert subscription.rejected?
   end
 
   test "confirms a subscription for valid identifiers" do
-    subscribe identifier: signed_stream_identifier(@post.to_gid.to_s), element_id: "bar"
+    subscribe identifier: signed_stream_identifier(@post.to_gid.to_s), element_id: "cubicle-bar"
 
     assert subscription.confirmed?
 
@@ -28,13 +33,13 @@ class Cubism::PresenceChannelTest < ActionCable::Channel::TestCase
   end
 
   test "adds user_id to the excluded users hash if the exclude_current_user param is passed" do
-    subscribe identifier: signed_stream_identifier(@post.to_gid.to_s), user: @user.to_sgid.to_s, element_id: "bar", exclude_current_user: true
+    subscribe identifier: signed_stream_identifier(@post.to_gid.to_s), element_id: "cubicle-bar", exclude_current_user: true
 
     assert_equal({"bar" => @user.id}, @post.excluded_user_id_for_element_id)
   end
 
   test "adds a user to the present users list when appear is called" do
-    subscribe identifier: signed_stream_identifier(@post.to_gid.to_s), user: @user.to_sgid.to_s, element_id: "bar"
+    subscribe identifier: signed_stream_identifier(@post.to_gid.to_s), element_id: "cubicle-foo"
     perform :appear
 
     assert_equal [@user.id], @post.present_users_for_scope("").to_a
@@ -44,17 +49,17 @@ class Cubism::PresenceChannelTest < ActionCable::Channel::TestCase
     assert_equal [], @post.present_users_for_scope("edit").to_a
     assert_equal [], @post.present_users_for_scope("show").to_a
 
-    subscribe identifier: signed_stream_identifier(@post.to_gid.to_s), user: @user.to_sgid.to_s, element_id: "bar", scope: "edit"
+    subscribe identifier: signed_stream_identifier(@post.to_gid.to_s), element_id: "cubicle-bar", scope: "edit"
     perform :appear
 
-    subscribe identifier: signed_stream_identifier(@post.to_gid.to_s), user: @user.to_sgid.to_s, element_id: "bar", scope: "show"
+    subscribe identifier: signed_stream_identifier(@post.to_gid.to_s), element_id: "bar", scope: "show"
 
     assert_equal [@user.id], @post.present_users_for_scope("edit").to_a
     assert_equal [], @post.present_users_for_scope("show").to_a
   end
 
   test "removes a user from the present users list when disappear is called" do
-    subscribe identifier: signed_stream_identifier(@post.to_gid.to_s), user: @user.to_sgid.to_s, element_id: "bar"
+    subscribe identifier: signed_stream_identifier(@post.to_gid.to_s), element_id: "cubicle-foo"
 
     perform :appear
 

--- a/test/helpers/cubism_helper_test.rb
+++ b/test/helpers/cubism_helper_test.rb
@@ -16,7 +16,6 @@ class CubismHelperTest < ActionView::TestCase
     cubicle_element = element.children.first
 
     assert_equal "cubicle-element", cubicle_element.name
-    assert_equal @user, GlobalID::Locator.locate_signed(cubicle_element["user"])
     assert_equal "connect", cubicle_element["appear-trigger"]
     assert_nil cubicle_element["disappear-trigger"]
     assert_nil cubicle_element["trigger-root"]


### PR DESCRIPTION
# Bug Fix

## Description

The passing of scopes as verifiable strings led to problems because of the not-idempotent nature. So in order to not compromise the presence functionality (i.e. providing scopes as plain text, thus making it guessable), I decided to move them into the block store digest. Now, to further streamline this, I decided to look up `user` from the block store in `PresenceChannel`, too.

Fixes #12 

## Checklist

- [X] My code follows the style guidelines of this project
- [X] Checks (StandardRB & Prettier-Standard) are passing
